### PR TITLE
Remove optional hostPort from task definition

### DIFF
--- a/alb/ecs_service.tf
+++ b/alb/ecs_service.tf
@@ -23,8 +23,7 @@ resource "aws_ecs_task_definition" "outyet" {
     "name": "outyet",
     "portMappings": [
       {
-        "containerPort": 8080,
-        "hostPort": 0
+        "containerPort": 8080
       }
     ]
   }


### PR DESCRIPTION
It's optional and this it to demonstrate that current version of Terraform (`0.8.4`) allows the user to leave out this parameter. Admittedly this is coming from the underlying AWS SDK rather than Terraform itself.